### PR TITLE
Refactor task handling and clean up method documentation

### DIFF
--- a/src/main/java/koko/command/DeadlineCommand.java
+++ b/src/main/java/koko/command/DeadlineCommand.java
@@ -22,14 +22,6 @@ public class DeadlineCommand extends Command {
         this.task = task;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         taskList.addTask(this.task);

--- a/src/main/java/koko/command/DeleteCommand.java
+++ b/src/main/java/koko/command/DeleteCommand.java
@@ -22,14 +22,6 @@ public class DeleteCommand extends Command {
         this.taskIndex = taskIndex;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         Task deletedTask = taskList.deleteTask(taskIndex);

--- a/src/main/java/koko/command/EventCommand.java
+++ b/src/main/java/koko/command/EventCommand.java
@@ -22,14 +22,6 @@ public class EventCommand extends Command {
         this.task = task;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         taskList.addTask(this.task);

--- a/src/main/java/koko/command/ExitCommand.java
+++ b/src/main/java/koko/command/ExitCommand.java
@@ -9,24 +9,11 @@ import koko.ui.Ui;
  */
 public class ExitCommand extends Command {
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         return ui.showExit();
     }
 
-    /**
-     * Returns whether this command should cause the application to exit.
-     *
-     * @return True since this command ends the program.
-     */
     @Override
     public boolean isExit() {
         return true;

--- a/src/main/java/koko/command/FindCommand.java
+++ b/src/main/java/koko/command/FindCommand.java
@@ -21,14 +21,6 @@ public class FindCommand extends Command {
         this.keyword = keyword;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         return taskList.findTask(keyword);

--- a/src/main/java/koko/command/ListCommand.java
+++ b/src/main/java/koko/command/ListCommand.java
@@ -9,14 +9,6 @@ import koko.ui.Ui;
  */
 public class ListCommand extends Command {
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         return taskList.listTasks();

--- a/src/main/java/koko/command/MarkCommand.java
+++ b/src/main/java/koko/command/MarkCommand.java
@@ -22,14 +22,6 @@ public class MarkCommand extends Command {
         this.taskIndex = taskIndex;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         Task markedTask = taskList.markTask(this.taskIndex);

--- a/src/main/java/koko/command/ToDoCommand.java
+++ b/src/main/java/koko/command/ToDoCommand.java
@@ -22,14 +22,6 @@ public class ToDoCommand extends Command {
         this.task = task;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         taskList.addTask(this.task);

--- a/src/main/java/koko/command/UnknownCommand.java
+++ b/src/main/java/koko/command/UnknownCommand.java
@@ -9,14 +9,6 @@ import koko.ui.Ui;
  */
 public class UnknownCommand extends Command {
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         return ui.showCommandNotFound();

--- a/src/main/java/koko/command/UnmarkCommand.java
+++ b/src/main/java/koko/command/UnmarkCommand.java
@@ -22,14 +22,6 @@ public class UnmarkCommand extends Command {
         this.taskIndex = taskIndex;
     }
 
-    /**
-     * Executes the command using the provided task list, user interface, and storage.
-     *
-     * @param taskList Task list containing all current tasks.
-     * @param ui User interface used for displaying messages to the user.
-     * @param storage Storage used for loading and saving task data.
-     * @return A response message to be shown to the user.
-     */
     @Override
     public String execute(TaskList taskList, Ui ui, Storage storage) {
         Task unmarkedTask = taskList.unmarkTask(taskIndex);

--- a/src/main/java/koko/parser/Parser.java
+++ b/src/main/java/koko/parser/Parser.java
@@ -30,6 +30,7 @@ public class Parser {
      */
     public Command parse(String fullCommand) {
         String[] parsedInput = parseInput(fullCommand);
+        // Default to UNKNOWN so invalid commands can be handled without crashing.
         CommandType commandType = CommandType.UNKNOWN;
         for (CommandType type : CommandType.values()) {
             if (type.name().equals(parsedInput[0])) {

--- a/src/main/java/koko/task/TaskList.java
+++ b/src/main/java/koko/task/TaskList.java
@@ -39,7 +39,7 @@ public class TaskList {
     }
 
     /**
-     * Prints all tasks in the task list.
+     * Returns all tasks in the task list.
      */
     public String listTasks() {
         String message = "Okay! Here is your quest list!";
@@ -85,6 +85,21 @@ public class TaskList {
      * @throws InvalidCommandInputException If the index is out of range.
      */
     public Task getTask(String index) {
+        return this.getTask(parseUserIndexToZeroBased(index));
+    }
+
+    /**
+     * Converts a one-based task index provided by the user into a zero-based index.
+     *
+     * The index is validated to ensure it is present, numeric, and within the
+     * valid range of tasks.
+     *
+     * @param index One-based task index provided by the user.
+     * @return Zero-based index corresponding to the task.
+     * @throws InvalidCommandFormatException If the index is missing or not a number.
+     * @throws InvalidCommandInputException If the index is outside the valid range.
+     */
+    public int parseUserIndexToZeroBased(String index) {
         if (index == null || index.isBlank()) {
             throw new InvalidCommandFormatException(
                     "Oi, which task?!\n"
@@ -107,8 +122,7 @@ public class TaskList {
                             + numTasks + "!\n"
             );
         }
-        int i = Integer.parseInt(index);
-        return this.tasks.get(i - 1);
+        return taskIndex - 1;
     }
 
     /**
@@ -138,14 +152,14 @@ public class TaskList {
      * @return Task that was deleted.
      */
     public Task deleteTask(String index) {
+        int i = parseUserIndexToZeroBased(index);
         Task deletedTask = this.getTask(index);
-        int i = Integer.parseInt(index);
         this.tasks.remove(i - 1);
         return deletedTask;
     }
 
     /**
-     * Prints tasks whose descriptions contain the given keyword.
+     * Returns tasks whose descriptions contain the given keyword.
      *
      * @param keyword Keyword to search for in task descriptions.
      */


### PR DESCRIPTION
Some task-related logic was duplicated across methods. In addition, some overridden methods repeated Javadoc that was already documented in their parent classes, adding unnecessary duplication.

Let's refactor task handling to centralize shared logic, update Javadoc to clearly document public method contracts where needed, and remove redundant documentation from overridden methods.

This improves readability and maintainability by reducing duplication and keeping documentation focused on meaningful behavior.